### PR TITLE
Update Policy 4.07 classification refs to 4.05 in 4.01, 4.02, 4.03

### DIFF
--- a/04/401.lyx
+++ b/04/401.lyx
@@ -484,7 +484,7 @@ Data and system classification for recovery prioritization —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1339,7 +1339,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2652,7 +2652,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2732,7 +2732,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2868,7 +2868,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2896,7 +2896,7 @@ Lifecycle Phase:
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2913,7 +2913,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2947,7 +2947,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/402.lyx
+++ b/04/402.lyx
@@ -645,7 +645,7 @@ Data and system classification for recovery —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1466,7 +1466,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1862,7 +1862,7 @@ Category D —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/403.lyx
+++ b/04/403.lyx
@@ -502,7 +502,7 @@ Data and system classification for recovery —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.05"
 plural "false"
 caps "false"
 noprefix "false"


### PR DESCRIPTION
All 12 cross-references to pol:4.07 (Data/System Classification for Recovery) updated to pol:4.05, reflecting the merge of that content into Policy 4.05. Affects: 8 refs in 4.01, 3 in 4.02, 1 in 4.03.

https://claude.ai/code/session_01MPZqiysXEzz6qjy1gA4N5d