### PR TITLE
Renumber policy cross-references (batch 2)

### DIFF
--- a/01/105.lyx
+++ b/01/105.lyx
@@ -472,7 +472,7 @@ nolink "false"
 ECIO Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.04"
+reference "app:6.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -671,7 +671,7 @@ Drafting
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.04"
+reference "app:6.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -760,7 +760,7 @@ The policy version shall be incremented in accordance with
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.04"
+reference "app:6.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -787,7 +787,7 @@ The previous version shall be marked "Obsolete" and archived in accordance with
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.04"
+reference "app:6.05"
 plural "false"
 caps "false"
 noprefix "false"
@@ -815,7 +815,7 @@ Retirement
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.04"
+reference "app:6.05"
 plural "false"
 caps "false"
 noprefix "false"

--- a/01/107.lyx
+++ b/01/107.lyx
@@ -301,7 +301,7 @@ nolink "false"
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -487,7 +487,7 @@ nolink "false"
 ECIO Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -607,7 +607,7 @@ The Information Operations Department is organized into hierarchical role tiers 
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -685,7 +685,7 @@ Competency Maintenance and Privileged Access Eligibility
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -834,7 +834,7 @@ IT Trainee Level (Tier L0)
 
 \lang english
 The following roles define the operational and governance structure of the Information Operations Department.
- Formal County position descriptions shall align with these definitions and with the STAK competencies in Appendix 6.05.
+ Formal County position descriptions shall align with these definitions and with the STAK competencies in Appendix 6.03.
 \end_layout
 
 \begin_layout Itemize
@@ -1393,7 +1393,7 @@ Definition
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1447,7 +1447,7 @@ Training
 Appendix 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "app:6.05"
+reference "app:6.03"
 plural "false"
 caps "false"
 noprefix "false"

--- a/01/109.lyx
+++ b/01/109.lyx
@@ -748,7 +748,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.04"
+reference "pol:5.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -764,7 +764,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.05"
 plural "false"
 caps "false"
 noprefix "false"

--- a/01/110.lyx
+++ b/01/110.lyx
@@ -468,7 +468,7 @@ Assessment
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -696,7 +696,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -714,7 +714,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/301.lyx
+++ b/03/301.lyx
@@ -366,7 +366,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -409,7 +409,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -605,7 +605,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -623,7 +623,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1153,7 +1153,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/302.lyx
+++ b/03/302.lyx
@@ -220,7 +220,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -261,7 +261,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -368,7 +368,7 @@ All performance data collected for the purpose of service level management,
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -441,7 +441,7 @@ IT Director
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -474,7 +474,7 @@ Assistant IT Director
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -557,7 +557,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -763,7 +763,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.04"
+reference "pol:5.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -781,7 +781,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -799,7 +799,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -817,7 +817,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1153,7 +1153,7 @@ Threshold 3 —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.04"
+reference "pol:5.03"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1200,7 +1200,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1275,7 +1275,7 @@ Quarterly Contribution to KPI Framework
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1291,7 +1291,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1395,7 +1395,7 @@ Vendor Breach Recording
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1422,7 +1422,7 @@ Contract Renewal Input
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1485,7 +1485,7 @@ Policy
 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1521,7 +1521,7 @@ Root Cause Assignment
 Upward Reporting to Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1542,7 +1542,7 @@ Policy 5.05
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1564,7 +1564,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/304.lyx
+++ b/03/304.lyx
@@ -857,7 +857,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/307.lyx
+++ b/03/307.lyx
@@ -364,7 +364,7 @@ This policy does not govern cybersecurity incident postmortems.
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/310.lyx
+++ b/03/310.lyx
@@ -398,7 +398,7 @@ Vendor deployments in cloud environments that ECIO does not directly control are
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -669,7 +669,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1395,7 +1395,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/314.lyx
+++ b/03/314.lyx
@@ -366,7 +366,7 @@ Cybersecurity incident post-mortems,
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1144,7 +1144,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1905,7 +1905,7 @@ Project KPI performance data shall feed into the broader performance management 
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/316.lyx
+++ b/03/316.lyx
@@ -534,7 +534,7 @@ KPI taxonomy and baseline definition —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1174,7 +1174,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1358,7 +1358,7 @@ A KPI underperformance pattern identified under
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.05"
+reference "pol:5.04"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/317.lyx
+++ b/03/317.lyx
@@ -341,7 +341,7 @@ Ongoing vendor compliance and third-party assurance —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -812,7 +812,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1143,7 +1143,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1161,7 +1161,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.07"
+reference "pol:5.06"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/401.lyx
+++ b/04/401.lyx
@@ -504,7 +504,7 @@ Postmortem review and lessons learned procedures —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -526,7 +526,7 @@ IR roles and contact directory —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -548,7 +548,7 @@ External partner integration procedures —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -749,7 +749,7 @@ Shall ensure the IR Roles and Contact Directory maintained under
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1357,7 +1357,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1375,7 +1375,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1393,7 +1393,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2080,7 +2080,7 @@ External Partner Relationships
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2212,7 +2212,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2983,7 +2983,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3010,7 +3010,7 @@ Lifecycle Phase:
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3048,7 +3048,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3080,7 +3080,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3101,7 +3101,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3129,7 +3129,7 @@ Lifecycle Phase:
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3181,7 +3181,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3217,7 +3217,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3247,7 +3247,7 @@ Lifecycle Phase:
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3286,7 +3286,7 @@ nolink "false"
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/402.lyx
+++ b/04/402.lyx
@@ -667,7 +667,7 @@ Postmortem review and lessons learned —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -689,7 +689,7 @@ Incident Response Roles and Contact Directory —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -711,7 +711,7 @@ External partner engagement procedures —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1484,7 +1484,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1502,7 +1502,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1520,7 +1520,7 @@ nolink "false"
 ECIO Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/403.lyx
+++ b/04/403.lyx
@@ -524,7 +524,7 @@ Postmortem review and lessons learned —
 Policy 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.08"
+reference "pol:4.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -761,7 +761,7 @@ Policy 5.02
 \series default
  and the annual policy review and maturity scoring process governed by 
 \series bold
-Policy 5.10
+Policy 5.07
 \series default
 .
 \end_layout
@@ -930,7 +930,7 @@ ECIO Policy 5.02:
 \begin_layout Standard
 
 \lang english
-ECIO Policy 5.10:
+ECIO Policy 5.07:
  Annual Policy Review and Maturity Scoring
 \end_layout
 


### PR DESCRIPTION
## Summary

- `pol:4.08` → `pol:4.07` (Postmortem Review): 3.07, 3.14, 4.01, 4.02, 4.03
- `pol:5.04` → `pol:5.03` (Compliance Monitoring): 1.09, 3.02
- `pol:5.05` → `pol:5.04` (Performance Metrics): 3.02, 3.04, 3.14, 3.16
- `pol:5.06` → `pol:5.05` (Security Control Assessment): 1.09
- `pol:5.07` → `pol:5.06` (Vendor Compliance): 1.10, 3.01, 3.02, 3.10, 3.17 — 1.04 intentionally skipped (its `5.07` refs mean Annual Policy Review)
- `Policy 5.10` → `Policy 5.07` (Annual Policy Review, literal text): 4.03
- `app:6.05` → `app:6.03` (STAK Matrix): 1.07
- `app:6.04` → `app:6.05` (Revision History): 1.05

15 files changed, 85 pure substitutions (no content edits).

https://claude.ai/code/session_01MPZqiysXEzz6qjy1gA4N5d