### PR TITLE
Update policy references and documentation formatting

### DIFF
--- a/01/110.lyx
+++ b/01/110.lyx
@@ -463,12 +463,12 @@ Assessment
 :
  Compliance shall be assessed through procurement review activities,
  audit support activities,
- and the annual policy review process defined in 
+ and the annual policy review process defined in
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -711,10 +711,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/02/201.lyx
+++ b/02/201.lyx
@@ -755,7 +755,7 @@ one (1) business day
 Prerequisite
 \series default
 :
- All users shall execute the Acceptable Use Policy Acknowledgment (found in Appendix 6.08) prior to being granted access to County IT resources.
+ All users shall execute the Acceptable Use Policy Acknowledgment (maintained in the System of Engagement (Redmine)) prior to being granted access to County IT resources.
 \end_layout
 
 \begin_layout Itemize

--- a/03/301.lyx
+++ b/03/301.lyx
@@ -361,12 +361,12 @@ nolink "false"
 
 
 \series default
- and the annual policy review and maturity scoring process defined in 
+ and the annual policy review and maturity scoring process defined in
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -620,10 +620,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/302.lyx
+++ b/03/302.lyx
@@ -552,12 +552,12 @@ nolink "false"
 
 
 \series default
- and the annual policy review and maturity scoring process defined in 
+ and the annual policy review and maturity scoring process defined in
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -814,10 +814,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/03/317.lyx
+++ b/03/317.lyx
@@ -807,12 +807,12 @@ nolink "false"
 
 
 \series default
- and the annual policy review and maturity scoring process defined in 
+ and the annual policy review and maturity scoring process defined in
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1158,10 +1158,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:5.06"
+reference "pol:5.07"
 plural "false"
 caps "false"
 noprefix "false"

--- a/04/401.lyx
+++ b/04/401.lyx
@@ -521,12 +521,12 @@ nolink "false"
 
 \lang english
 IR roles and contact directory —
- governed by 
+ governed by
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -543,12 +543,12 @@ nolink "false"
 
 \lang english
 External partner integration procedures —
- governed by 
+ governed by
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -744,12 +744,12 @@ Shall serve as the primary operational coordinator for incident response activit
 \begin_layout Itemize
 
 \lang english
-Shall ensure the IR Roles and Contact Directory maintained under 
+Shall ensure the IR Roles and Contact Directory maintained under
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1372,10 +1372,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1390,10 +1390,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -2075,12 +2075,12 @@ External Partner Relationships
  incident coordination resources,
  and analytical support from the broader state and national cybersecurity community.
  The ECIO also maintains working relationships with the Federal Bureau of Investigation (FBI) and the Nevada Department of Public Safety (DPS) for purposes of incident coordination and law enforcement referral.
- The operational procedures governing engagement with these and other external partners are established in 
+ The operational procedures governing engagement with these and other external partners are established in
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3098,10 +3098,10 @@ nolink "false"
 
 \series bold
 \lang english
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3126,10 +3126,10 @@ Lifecycle Phase:
 
 \series bold
 \lang english
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3176,12 +3176,12 @@ nolink "false"
 
 \series default
  and are incorporated by reference.
- 
+
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3214,10 +3214,10 @@ nolink "false"
 
 \series bold
 \lang english
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3226,9 +3226,7 @@ nolink "false"
 \end_inset
 
  —
- Integration with Local,
- State,
- and Federal Partners
+ Communication Protocols and Partner Integration
 \end_layout
 
 \begin_layout Standard
@@ -3244,10 +3242,10 @@ Lifecycle Phase:
 
 \series bold
 \lang english
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3257,17 +3255,32 @@ nolink "false"
 
 
 \series default
- governs the operational procedures for engaging external partners during a cybersecurity incident.
- It establishes the conditions and criteria under which ECIO initiates contact with the MS-ISAC,
+ governs incident communication protocols and incorporates external partner integration as a dedicated subsection.
+ The partner integration subsection of
+\series bold
+Policy
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "pol:4.06"
+plural "false"
+caps "false"
+noprefix "false"
+nolink "false"
+
+\end_inset
+
+
+\series default
+ establishes the conditions and criteria under which ECIO initiates contact with the MS-ISAC,
  NV-ISAC,
  FBI,
  Nevada DPS,
  and other external entities;
  the authorization requirements for sharing incident information with external parties;
  and the documentation obligations for all external partner interactions.
- All external partner engagement during an active incident requires Incident Commander authorization and shall be executed consistent with the communication constraints established in 
+ All external partner engagement during an active incident requires Incident Commander authorization and shall be executed within the One Voice Rule and communication authorization framework established by
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "pol:4.06"
@@ -3281,12 +3294,13 @@ nolink "false"
 
 \series default
 .
- 
+ Partner integration is not governed by a standalone policy;
+ it is addressed as an integrated subsection of
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -3296,8 +3310,7 @@ nolink "false"
 
 
 \series default
- does not modify the One Voice Rule or the communication authorization framework;
- it establishes the partner-specific procedures that operate within those constraints.
+.
 \end_layout
 
 \end_body

--- a/04/402.lyx
+++ b/04/402.lyx
@@ -684,12 +684,12 @@ nolink "false"
 
 \lang english
 Incident Response Roles and Contact Directory —
- 
+
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -706,12 +706,12 @@ nolink "false"
 
 \lang english
 External partner engagement procedures —
- 
+
 \series bold
-Policy 
+Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1499,10 +1499,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.08"
 plural "false"
 caps "false"
 noprefix "false"
@@ -1517,10 +1517,10 @@ nolink "false"
 \begin_layout Itemize
 
 \lang english
-ECIO Policy 
+ECIO Policy
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "pol:4.07"
+reference "pol:4.06"
 plural "false"
 caps "false"
 noprefix "false"


### PR DESCRIPTION
## Summary
This PR updates policy references throughout the documentation to reflect policy reorganization and makes minor formatting corrections to remove trailing whitespace.

## Key Changes

- **Policy Reference Updates**: Updated cross-references from pol:4.07 to pol:4.08 and pol:4.06 across multiple documents (04/401.lyx, 04/402.lyx) to align with revised policy structure for IR roles, contact directories, and external partner integration procedures

- **Policy Consolidation**: Restructured the "Integration with Local, State, and Federal Partners" section to clarify that partner integration is now addressed as a subsection of pol:4.06 (Communication Protocols) rather than as a standalone policy reference

- **Policy Numbering Alignment**: Updated references from pol:5.06 to pol:5.07 in compliance and assessment-related documents (01/110.lyx, 03/301.lyx, 03/302.lyx, 03/317.lyx) to reflect policy renumbering

- **Documentation Clarification**: Enhanced explanatory text in 04/401.lyx to clarify the relationship between the One Voice Rule, communication authorization framework, and partner integration procedures

- **Formatting Cleanup**: Removed trailing whitespace from multiple policy reference lines and text passages throughout all modified files

- **Appendix Reference Update**: Changed reference from "Appendix 6.08" to "System of Engagement (Redmine)" for the Acceptable Use Policy Acknowledgment location in 02/201.lyx

## Implementation Details

All changes maintain document structure and formatting while updating internal cross-references and clarifying policy governance relationships. The modifications ensure consistency across the incident response and compliance documentation suite.

https://claude.ai/code/session_01FZ8VGP7DEagutJt5QMvyrv